### PR TITLE
ci(codeql): enable security-extended and security-and-quality query packs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,12 +71,8 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        # See https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        queries: security-extended,security-and-quality
 
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above


### PR DESCRIPTION
## Summary
Enable CodeQL's `security-extended` and `security-and-quality` query packs in `.github/workflows/codeql.yml`. Also remove the boilerplate comment block from the `codeql-action` template.

## Why
The default CodeQL setup runs only the baseline `code-scanning` pack, which has narrower CWE coverage. For a repo this small (no compiled languages, no large dependency surface), adding the extended packs has negligible cost and surfaces additional findings:
- `security-extended` — broader CWE coverage (e.g. less-common injection sinks, weak crypto patterns)
- `security-and-quality` — maintainability and reliability checks alongside security

Both packs are GitHub-published; no third-party query install needed.

## Heads up
The first run after merging will likely surface some new findings. Plan to triage them (mark false positives as dismissed, fix true positives) — recommend you start with Python before JS/TS since the script surface is smaller.

## Test plan
- [x] Workflow YAML still parses
- [ ] First CodeQL run on this PR completes successfully
- [ ] Triage any new findings on first post-merge scheduled run (2026-05-21, per the existing `cron: '41 7 * * 4'`)
