### PR TITLE
chore: drop stale references in requirements.txt and SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ This repository contains a static literature review database and webapp. It does
 | Component | Version | Supported |
 |-----------|---------|-----------|
 | Webapp (Astro) | latest on `main` | Yes |
-| Data schema | v1.0 | Yes |
+| Data schema | latest on `main` | Yes |
 | Python scripts | latest on `main` | Yes |
 
 ## Reporting a Vulnerability

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,2 @@
 jsonschema>=4.26.0
 requests>=2.33.1
-python-Levenshtein>=0.27.3


### PR DESCRIPTION
## Summary
Two small cleanups for inconsistencies between docs/config and the actual repo state.

### `scripts/requirements.txt`
Remove `python-Levenshtein>=0.27.3`. Nothing under `scripts/` imports it — `deduplicate.py`'s `title_similarity()` uses Jaccard on word sets. Removing it shaves a build step from `pip install -r scripts/requirements.txt` and keeps Dependabot from opening PRs for an unused dep.

If we later want fuzzier title matching (e.g. token-set or edit-distance ratio to catch reordered titles like "Jailbreaking LLMs" vs "LLM Jailbreak"), the dependency can come back alongside the change that actually uses it.

### `SECURITY.md`
The "Supported Versions" table claimed `Data schema | v1.0 | Yes`, but `schemas/literature-entry.schema.json` has no version field — the claim wasn't backed by anything. Align that row with the other two rows (`latest on main`) instead of inventing a version.

## Test plan
- [x] `grep -rn -i 'levenshtein' scripts/` returns only the now-removed requirements.txt line
- [x] `python scripts/validate_data.py` still passes (already verified — only uses `jsonschema`)
- [ ] Next Dependabot pip run no longer opens PRs for python-Levenshtein
