### PR TITLE
data: backfill DOIs for 23 papers; add scripts/backfill_dois.py

### DIFF
--- a/data/literature.json
+++ b/data/literature.json
@@ -133,11 +133,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2307.02483"
+        "arxiv_id": "2307.02483",
+        "doi": "10.52202/075280-3508"
       },
       "citation_count": 520,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/075280-3508"
     },
     {
       "id": "llmsec-2024-00002",
@@ -560,11 +562,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2310.10501"
+        "arxiv_id": "2310.10501",
+        "doi": "10.18653/v1/2023.emnlp-demo.40"
       },
       "citation_count": 190,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.18653/v1/2023.emnlp-demo.40"
     },
     {
       "id": "llmsec-2024-00008",
@@ -608,11 +612,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2312.02003"
+        "arxiv_id": "2312.02003",
+        "doi": "10.1016/j.hcc.2024.100211"
       },
       "citation_count": 350,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1016/j.hcc.2024.100211"
     },
     {
       "id": "llmsec-2024-00009",
@@ -696,11 +702,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2312.10982"
+        "arxiv_id": "2312.10982",
+        "doi": "10.1007/978-981-97-1274-8_6"
       },
       "citation_count": 90,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1007/978-981-97-1274-8_6"
     },
     {
       "id": "llmsec-2024-00011",
@@ -788,11 +796,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2406.13352"
+        "arxiv_id": "2406.13352",
+        "doi": "10.52202/079017-2636"
       },
       "citation_count": 75,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/079017-2636"
     },
     {
       "id": "llmsec-2024-00013",
@@ -878,11 +888,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2308.03825"
+        "arxiv_id": "2308.03825",
+        "doi": "10.1145/3658644.3670388"
       },
       "citation_count": 310,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1145/3658644.3670388"
     },
     {
       "id": "llmsec-2023-00006",
@@ -927,11 +939,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2304.05197"
+        "arxiv_id": "2304.05197",
+        "doi": "10.18653/v1/2023.findings-emnlp.272"
       },
       "citation_count": 175,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.18653/v1/2023.findings-emnlp.272"
     },
     {
       "id": "llmsec-2024-00014",
@@ -1228,11 +1242,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2401.10019"
+        "arxiv_id": "2401.10019",
+        "doi": "10.18653/v1/2024.findings-emnlp.79"
       },
       "citation_count": 35,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.18653/v1/2024.findings-emnlp.79"
     },
     {
       "id": "llmsec-2024-00020",
@@ -1749,11 +1765,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2402.06677"
+        "arxiv_id": "2402.06677",
+        "doi": "10.21468/SciPostPhys.20.1.002"
       },
       "citation_count": 55,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.21468/SciPostPhys.20.1.002"
     },
     {
       "id": "llmsec-2024-00030",
@@ -1892,11 +1910,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2310.17124"
+        "arxiv_id": "2310.17124",
+        "doi": "10.1145/3650203.3663331"
       },
       "citation_count": 70,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1145/3650203.3663331"
     },
     {
       "id": "llmsec-2024-00033",
@@ -1941,11 +1961,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2306.06815"
+        "arxiv_id": "2306.06815",
+        "doi": "10.52202/075280-2866"
       },
       "citation_count": 85,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/075280-2866"
     },
     {
       "id": "llmsec-2024-00034",
@@ -2119,11 +2141,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2302.04761"
+        "arxiv_id": "2302.04761",
+        "doi": "10.52202/075280-2997"
       },
       "citation_count": 1400,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/075280-2997"
     },
     {
       "id": "llmsec-2024-00038",
@@ -2182,11 +2206,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2308.14840"
+        "arxiv_id": "2308.14840",
+        "doi": "10.1561/3300000041"
       },
       "citation_count": 280,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1561/3300000041"
     },
     {
       "id": "llmsec-2025-00001",
@@ -2216,9 +2242,12 @@
       "added_date": "2026-04-14",
       "added_by": "manual",
       "source_api": "manual",
-      "external_ids": {},
+      "external_ids": {
+        "doi": "10.1117/12.3025025"
+      },
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1117/12.3025025"
     },
     {
       "id": "llmsec-2024-00039",
@@ -2590,11 +2619,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2312.14197"
+        "arxiv_id": "2312.14197",
+        "doi": "10.1145/3690624.3709179"
       },
       "citation_count": 60,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1145/3690624.3709179"
     },
     {
       "id": "llmsec-2025-00002",
@@ -2954,11 +2985,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2306.11698"
+        "arxiv_id": "2306.11698",
+        "doi": "10.52202/075280-1361"
       },
       "citation_count": 520,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/075280-1361"
     },
     {
       "id": "llmsec-2024-00052",
@@ -3281,11 +3314,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2407.19354"
+        "arxiv_id": "2407.19354",
+        "doi": "10.1145/3773080"
       },
       "citation_count": 35,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1145/3773080"
     },
     {
       "id": "llmsec-2024-00060",
@@ -3372,11 +3407,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2401.06373"
+        "arxiv_id": "2401.06373",
+        "doi": "10.18653/v1/2024.acl-long.773"
       },
       "citation_count": 85,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.18653/v1/2024.acl-long.773"
     },
     {
       "id": "llmsec-2025-00006",
@@ -3715,11 +3752,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2405.15793"
+        "arxiv_id": "2405.15793",
+        "doi": "10.52202/079017-1601"
       },
       "citation_count": 200,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/079017-1601"
     },
     {
       "id": "llmsec-2025-00015",
@@ -3848,11 +3887,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2302.10149"
+        "arxiv_id": "2302.10149",
+        "doi": "10.1109/sp54263.2024.00179"
       },
       "citation_count": 250,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1109/sp54263.2024.00179"
     },
     {
       "id": "llmsec-2025-00018",
@@ -3892,11 +3933,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2306.13213"
+        "arxiv_id": "2306.13213",
+        "doi": "10.1609/aaai.v38i19.30150"
       },
       "citation_count": 220,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.1609/aaai.v38i19.30150"
     },
     {
       "id": "llmsec-2025-00019",
@@ -3939,11 +3982,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2306.15447"
+        "arxiv_id": "2306.15447",
+        "doi": "10.52202/075280-2687"
       },
       "citation_count": 180,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/075280-2687"
     },
     {
       "id": "llmsec-2025-00020",
@@ -4191,11 +4236,13 @@
       "added_by": "manual",
       "source_api": "manual",
       "external_ids": {
-        "arxiv_id": "2406.18495"
+        "arxiv_id": "2406.18495",
+        "doi": "10.52202/079017-0261"
       },
       "citation_count": 30,
       "open_access": true,
-      "reviewed": true
+      "reviewed": true,
+      "doi": "10.52202/079017-0261"
     },
     {
       "id": "llmsec-2025-00026",

--- a/scripts/backfill_dois.py
+++ b/scripts/backfill_dois.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Backfill DOIs for paper and book entries in data/literature.json.
+
+Strategy per entry (only entries of type=paper or type=book that are missing
+both `doi` and `external_ids.doi` are touched):
+
+1. If `external_ids.arxiv_id` is present, look up the arXiv metadata and
+   pull `<arxiv:doi>` if arXiv has it (only set for papers that were also
+   formally published).
+2. Otherwise, query CrossRef by bibliographic title and accept the first
+   result whose normalized-title Jaccard similarity >= 0.85 and year is
+   within +/-1 of the entry year.
+
+When a DOI is found it is written to both `entry["doi"]` (top-level,
+matching the schema's existing convention) and `entry["external_ids"]["doi"]`
+to stay consistent with how other indexes are populated.
+
+The script is idempotent -- entries that already have a DOI are skipped.
+Re-run safely after new entries land.
+
+Usage: python scripts/backfill_dois.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LIT_PATH = ROOT / "data" / "literature.json"
+
+ARXIV_API = "https://export.arxiv.org/api/query"
+CROSSREF_API = "https://api.crossref.org/works"
+ARXIV_NS = {"atom": "http://www.w3.org/2005/Atom", "arxiv": "http://arxiv.org/schemas/atom"}
+
+USER_AGENT = "GenAI-Security-Literature-Review/1.0 (mailto:emmanuelgjr@gmail.com)"
+
+ARXIV_DELAY_SEC = 3.0  # arXiv requests >=3s between requests
+CROSSREF_DELAY_SEC = 1.0
+HTTP_TIMEOUT = 30
+
+
+def normalize_title(title: str) -> str:
+    title = title.lower().strip()
+    title = re.sub(r"[^a-z0-9\s]", "", title)
+    title = re.sub(r"\s+", " ", title)
+    return title
+
+
+def title_jaccard(a: str, b: str) -> float:
+    sa, sb = set(normalize_title(a).split()), set(normalize_title(b).split())
+    if not sa or not sb:
+        return 0.0
+    return len(sa & sb) / len(sa | sb)
+
+
+def http_get(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        return resp.read()
+
+
+def arxiv_lookup_doi(arxiv_id: str) -> str | None:
+    """Return the DOI arXiv has for `arxiv_id`, or None if absent."""
+    url = f"{ARXIV_API}?id_list={urllib.parse.quote(arxiv_id)}"
+    xml_data = http_get(url)
+    root = ET.fromstring(xml_data)
+    entry = root.find("atom:entry", ARXIV_NS)
+    if entry is None:
+        return None
+    doi_el = entry.find("arxiv:doi", ARXIV_NS)
+    if doi_el is None or not (doi_el.text or "").strip():
+        return None
+    return doi_el.text.strip()
+
+
+def crossref_lookup_doi(title: str, year: int | None) -> str | None:
+    """Search CrossRef for `title`; return DOI of first close match (or None)."""
+    params = urllib.parse.urlencode({
+        "query.bibliographic": title,
+        "rows": 5,
+        "select": "DOI,title,issued",
+    })
+    url = f"{CROSSREF_API}?{params}"
+    data = json.loads(http_get(url).decode("utf-8"))
+    items = data.get("message", {}).get("items", [])
+
+    for item in items:
+        cand_titles = item.get("title", [])
+        if not cand_titles:
+            continue
+        cand_title = cand_titles[0]
+        if title_jaccard(title, cand_title) < 0.85:
+            continue
+        if year is not None:
+            issued = item.get("issued", {}).get("date-parts", [[None]])[0]
+            cand_year = issued[0] if issued else None
+            if cand_year is not None and abs(cand_year - year) > 1:
+                continue
+        doi = item.get("DOI")
+        if doi:
+            return doi
+    return None
+
+
+def set_doi(entry: dict, doi: str) -> None:
+    entry["doi"] = doi
+    entry.setdefault("external_ids", {})["doi"] = doi
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would change but do not write the file")
+    args = parser.parse_args()
+
+    with open(LIT_PATH, encoding="utf-8") as f:
+        literature = json.load(f)
+
+    candidates = [
+        e for e in literature["entries"]
+        if e["type"] in ("paper", "book")
+        and not e.get("doi")
+        and not e.get("external_ids", {}).get("doi")
+    ]
+
+    print(f"{len(candidates)} candidates need a DOI lookup")
+
+    found_arxiv = 0
+    found_crossref = 0
+    not_found = 0
+    last_arxiv = 0.0
+    last_crossref = 0.0
+
+    for i, entry in enumerate(candidates, start=1):
+        arxiv_id = entry.get("external_ids", {}).get("arxiv_id")
+        title = entry["title"]
+        year = entry.get("year")
+        prefix = f"[{i:3d}/{len(candidates)}] {entry['id']}"
+
+        doi: str | None = None
+        source: str | None = None
+
+        if arxiv_id:
+            wait = ARXIV_DELAY_SEC - (time.monotonic() - last_arxiv)
+            if wait > 0:
+                time.sleep(wait)
+            try:
+                doi = arxiv_lookup_doi(arxiv_id)
+            except Exception as e:  # noqa: BLE001
+                print(f"{prefix} arXiv lookup error: {e}", file=sys.stderr)
+            last_arxiv = time.monotonic()
+            if doi:
+                source = "arxiv"
+                found_arxiv += 1
+
+        if not doi:
+            wait = CROSSREF_DELAY_SEC - (time.monotonic() - last_crossref)
+            if wait > 0:
+                time.sleep(wait)
+            try:
+                doi = crossref_lookup_doi(title, year)
+            except Exception as e:  # noqa: BLE001
+                print(f"{prefix} CrossRef lookup error: {e}", file=sys.stderr)
+            last_crossref = time.monotonic()
+            if doi:
+                source = "crossref"
+                found_crossref += 1
+
+        if doi:
+            set_doi(entry, doi)
+            print(f"{prefix} OK ({source}): {doi}  -- {title[:70]}")
+        else:
+            not_found += 1
+            print(f"{prefix} no DOI found  -- {title[:70]}")
+
+    print(
+        f"\nDone. Filled {found_arxiv + found_crossref}/{len(candidates)} "
+        f"(arXiv: {found_arxiv}, CrossRef: {found_crossref}, not found: {not_found})"
+    )
+
+    if args.dry_run:
+        print("Dry run -- not writing literature.json")
+        return 0
+
+    if found_arxiv + found_crossref == 0:
+        print("No changes to write.")
+        return 0
+
+    with open(LIT_PATH, "w", encoding="utf-8") as f:
+        json.dump(literature, f, indent=2, ensure_ascii=False)
+    print(f"Updated {LIT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Before this PR, only 2 of 100 entries in `data/literature.json` had a `doi` populated, even though the schema has had `doi` and `external_ids.doi` fields all along. This adds:

- `scripts/backfill_dois.py` — small idempotent script that fills in missing DOIs via arXiv + CrossRef
- Applies it once over the existing data — **23 of 77 candidate entries gained a DOI** (arXiv: 5, CrossRef: 18)

## Strategy
For each entry of `type=paper` or `type=book` that is missing both `doi` and `external_ids.doi`:

1. If `external_ids.arxiv_id` is set → query arXiv for `<arxiv:doi>` (only set when the paper was also formally published)
2. Otherwise → CrossRef bibliographic title search; accept the first hit whose normalized-title Jaccard ≥ `0.85` **and** year is within ±1 of the entry year

DOIs are written to **both** `entry["doi"]` and `entry["external_ids"]["doi"]` to stay consistent with how other indexes are populated. Entry types `standard`, `report`, `tool`, `dataset` are skipped — DOIs aren't conventional for those.

## Verification
- [x] `python scripts/validate_data.py` passes (100 entries, all categories valid)
- [x] Spot-checked 5 of the new DOIs against CrossRef's authoritative title field — all 5 resolve to the correct paper:
  - `llmsec-2024-00001` "Jailbroken..." → `10.52202/075280-3508` ✓
  - `llmsec-2024-00051` "DecodingTrust..." → `10.52202/075280-1361` ✓
  - `llmsec-2025-00018` "Visual Adversarial Examples Jailbreak..." → `10.1609/aaai.v38i19.30150` ✓
  - `llmsec-2025-00017` "Poisoning Web-Scale Training Datasets..." → `10.1109/sp54263.2024.00179` ✓
  - `llmsec-2024-00061` "How Johnny Can Persuade LLMs..." → `10.18653/v1/2024.acl-long.773` ✓

## Why only 23 of 77?
- ~50 are arXiv-only preprints whose arXiv record has no DOI (the paper hasn't been formally published, or the authors didn't backfill the DOI on arXiv after publication)
- A handful are non-paper-but-typed-as-paper entries (e.g. `OWASP LLM AI Security & Governance Checklist`, `CISA: Roadmap for Artificial Intelligence`) that legitimately don't have DOIs
- A few CrossRef searches returned nothing close enough to the threshold

Future arXiv → DOI promotions will be picked up by re-running the script.

## How to re-run
```bash
python scripts/backfill_dois.py            # do it for real
python scripts/backfill_dois.py --dry-run  # see what would change without writing
```
Idempotent — only entries currently missing a DOI are touched.
