### PR TITLE
docs(README): fix stale category count (42 -> 46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Fetch Papers](https://github.com/emmanuelgjr/GenAI-Security-Literature-Review/actions/workflows/fetch-papers.yml/badge.svg)](https://github.com/emmanuelgjr/GenAI-Security-Literature-Review/actions/workflows/fetch-papers.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A comprehensive, community-driven, auto-updating literature review of **GenAI and LLM security** research, standards, tools, and resources. Currently tracking **100 resources** across **42 categories** with weekly automated updates from academic APIs.
+A comprehensive, community-driven, auto-updating literature review of **GenAI and LLM security** research, standards, tools, and resources. Currently tracking **100 resources** across **46 categories** with weekly automated updates from academic APIs.
 
 **[Browse the Interactive Webapp](https://emmanuelgjr.github.io/GenAI-Security-Literature-Review/)**
 
@@ -59,7 +59,7 @@ The static webapp (deployed to GitHub Pages) provides:
 ```
 data/
   literature.json      # Core database (100 curated entries)
-  taxonomy.json        # 8 domains, 42 category definitions
+  taxonomy.json        # 8 domains, 46 category definitions
   frameworks.json      # OWASP/NIST/MITRE/ISO framework definitions
   sources.json         # Automation source configuration
 schemas/               # JSON Schema for data validation


### PR DESCRIPTION
## Summary
README claimed `42 categories` in two places (the badge paragraph and the `Repository Structure` block) but `data/taxonomy.json` has 46 (9 attacks + 8 defenses + 5 privacy + 5 governance + 4 red-teaming + 5 infrastructure + 5 agentic + 5 meta). Updated both occurrences to 46.

Verified with:
```bash
python -c "import json; d=json.load(open('data/taxonomy.json')); print(sum(len(dom['categories']) for dom in d['domains']))"
# -> 46
```
