### PR TITLE
webapp: add @astrojs/sitemap integration for SEO

### DIFF
--- a/webapp/astro.config.mjs
+++ b/webapp/astro.config.mjs
@@ -1,10 +1,11 @@
 import { defineConfig } from 'astro/config';
 import preact from '@astrojs/preact';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
   site: 'https://emmanuelgjr.github.io',
   base: '/GenAI-Security-Literature-Review/',
   trailingSlash: 'always',
-  integrations: [preact()],
+  integrations: [preact(), sitemap()],
   output: 'static',
 });

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/preact": "^5.1.1",
+        "@astrojs/sitemap": "^3.7.2",
         "astro": "^6.1.8",
         "fuse.js": "^7.0.0",
         "preact": "^10.24.0"
@@ -106,6 +107,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2132,6 +2144,24 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2180,7 +2210,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5606,6 +5635,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -5654,6 +5702,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5904,6 +5958,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,10 +10,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^6.1.8",
     "@astrojs/preact": "^5.1.1",
-    "preact": "^10.24.0",
-    "fuse.js": "^7.0.0"
+    "@astrojs/sitemap": "^3.7.2",
+    "astro": "^6.1.8",
+    "fuse.js": "^7.0.0",
+    "preact": "^10.24.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Summary
Add the official `@astrojs/sitemap` integration to the webapp build. Astro auto-generates `sitemap-index.xml` + `sitemap-0.xml` using the existing `site` + `base` config, so search engines can discover all 151 routes (every entry page, every browse-by-category page, plus root, about, frameworks, search).

## Verified
Local `npm run build` output:
```
[@astrojs/sitemap] `sitemap-index.xml` created at `dist`
[build] 151 page(s) built in 1.90s

dist/sitemap-index.xml    225 B
dist/sitemap-0.xml         16.7 KB  (151 URLs)
```

Sample entries from the generated sitemap:
```xml
<loc>https://emmanuelgjr.github.io/GenAI-Security-Literature-Review/</loc>
<loc>https://emmanuelgjr.github.io/GenAI-Security-Literature-Review/browse/prompt-injection/</loc>
<loc>https://emmanuelgjr.github.io/GenAI-Security-Literature-Review/entry/llmsec-2024-00001/</loc>
```
All URLs correctly use the production `site` + `base` prefix.

## Heads-up on PR ordering
This PR intentionally does **not** include `webapp/package-lock.json` even though `npm install` generated one locally. The lockfile is the subject of [#20](https://github.com/emmanuelgjr/GenAI-Security-Literature-Review/pull/20); including it in two PRs would conflict. Recommended merge order:

1. Merge #20 (lockfile + `npm ci`) first
2. Rebase this branch onto main, then run `cd webapp && npm install` to regenerate the lockfile with `@astrojs/sitemap` included, commit, push
3. Merge this PR

If this PR merges before #20, the lockfile in #20 will need to be regenerated to include `@astrojs/sitemap` — same outcome, just inverted.

## Follow-up suggestions
- Submit the sitemap URL to Google Search Console: `https://emmanuelgjr.github.io/GenAI-Security-Literature-Review/sitemap-index.xml`
- Optionally add `robots.txt` to `webapp/public/` pointing at the sitemap (one-line file)
